### PR TITLE
Task Pipeline frontend & Collections Support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '2'
 services:
+
   context:
     build: .
     volumes:
@@ -41,7 +42,11 @@ services:
         -----END RSA PRIVATE KEY-----
 
   patchbay:
-    image: datatogether/patchbay:latest
+    # image: datatogether/patchbay:latest
+    build: $GOPATH/src/github.com/datatogether/patchbay/
+    volumes:
+      - $GOPATH/src/github.com/datatogether/patchbay:/go/src/github.com/datatogether/patchbay
+      - ./sql:/sql
     ports:
      - 3000:3000
     networks:
@@ -68,7 +73,48 @@ services:
         k4uJgqHl8hgs3bndGibFuepdLWJed7YXa+eF57FdmA==
         -----END RSA PRIVATE KEY-----
       - WEBAPP_SCRIPTS=http://localhost:4000/static/bundle.js
+      - TASKS_SERVICE_URL=task-mgmt:4400
 
+  task-mgmt:
+    build: $GOPATH/src/github.com/datatogether/task-mgmt/
+    volumes:
+      - $GOPATH/src/github.com/datatogether/task-mgmt:/go/src/github.com/datatogether/task-mgmt
+      - ./sql:/sql
+    ports:
+     - 3400:3400
+     - 4400:4400
+    networks:
+      - back-tier
+    depends_on:
+      - ipfs
+      - rabbitmq
+      - postgres
+    environment:
+      - PORT=3400
+      - TLS=false
+      - GOLANG_ENV=develop
+      - POSTGRES_DB_URL=postgres://postgres@postgres/postgres?sslmode=disable
+      - PUBLIC_KEY=nothing_yet
+      - POSTMARK_KEY=POSTMARK_API_TEST
+      - EMAIL_NOTIFICATION_RECIPIENTS=brendan@qri.io
+      - GITHUB_LOGIN_URL=http://localhost:3100/oauth/github
+      - AMQP_URL=amqp://guest:guest@rabbitmq:5672/
+      - IPFS_API_URL=http://ipfs:5001/api/v0
+      - RPC_PORT=4400
+
+  ipfs:
+    image: "ipfs/go-ipfs:latest"
+    networks:
+      - back-tier
+    ports:
+      - 5001:5001
+  rabbitmq:
+    image: "library/rabbitmq:latest"
+    networks:
+      - back-tier
+    ports:
+      - 5672:5672
+      - 15672:15672
   postgres:
     image: postgres:9.6-alpine
     networks:

--- a/src/js/actions/collections.js
+++ b/src/js/actions/collections.js
@@ -80,7 +80,7 @@ export const COLLECTION_SAVE_REQUEST = "COLLECTION_SAVE_REQUEST";
 export const COLLECTION_SAVE_SUCCESS = "COLLECTION_SAVE_SUCCESS";
 export const COLLECTION_SAVE_FAILURE = "COLLECTION_SAVE_FAILURE";
 
-export function saveCollection(collection = {}) {
+export function saveCollection(collection = {}, callback) {
   return (dispatch) => {
     analytics.track(collection.id ? "Created Collection" : "Saved Collection", collection);
     return dispatch({
@@ -94,6 +94,9 @@ export function saveCollection(collection = {}) {
     }).then((action) => {
       if (action.type == COLLECTION_SAVE_SUCCESS) {
         cancelCollectionEdit(collection.keyId, collection.subject);
+        if (typeof callback == "function") {
+          callback(action.data);
+        }
       }
     });
   };
@@ -103,7 +106,7 @@ export const COLLECTION_DELETE_REQUEST = "COLLECTION_DELETE_REQUEST";
 export const COLLECTION_DELETE_SUCCESS = "COLLECTION_DELETE_SUCCESS";
 export const COLLECTION_DELETE_FAILURE = "COLLECTION_DELETE_FAILURE";
 
-export function deleteCollection(collection = {}) {
+export function deleteCollection(collection = {}, callback) {
   analytics.track("Deleted Collection", collection);
   return (dispatch) => {
     return dispatch({
@@ -114,6 +117,12 @@ export function deleteCollection(collection = {}) {
         method: "DELETE",
         data: collection,
       },
-    });
+    }).then((action) => {
+      if (action.type == COLLECTION_DELETE_SUCCESS) {
+        if (typeof callback == "function") {
+          callback(action.data);
+        }
+      }
+    })
   };
 }

--- a/src/js/actions/collections.js
+++ b/src/js/actions/collections.js
@@ -5,10 +5,10 @@ import analytics from '../analytics';
 import { newLocalModel, updateLocalModel, editModel, removeLocalModel } from './locals';
 
 const blankCollection = {
-  meta: {
-    title: "",
-    description: "",
-  },
+  title: "",
+  description: "",
+  schema: ["hash","url","description"],
+  contents: [],
 };
 
 const COLLECTION_NEW = "COLLECTION_NEW";
@@ -89,7 +89,7 @@ export function saveCollection(collection = {}) {
         schema: Schemas.COLLECTION,
         method: (collection.id == "new") ? "POST" : "PUT",
         endpoint: "/collections",
-        data: collection,
+        data: (collection.id != "new") ? {collection} : { collection: Object.assign({}, collection, { id : "" }) },
       },
     }).then((action) => {
       if (action.type == COLLECTION_SAVE_SUCCESS) {

--- a/src/js/actions/tasks.js
+++ b/src/js/actions/tasks.js
@@ -76,41 +76,41 @@ export function loadTask(id = "") {
   };
 }
 
-export const TASK_SAVE_REQUEST = "TASK_SAVE_REQUEST";
-export const TASK_SAVE_SUCCESS = "TASK_SAVE_SUCCESS";
-export const TASK_SAVE_FAILURE = "TASK_SAVE_FAILURE";
+export const TASK_ENQUEUE_REQUEST = "TASK_ENQUEUE_REQUEST";
+export const TASK_ENQUEUE_SUCCESS = "TASK_ENQUEUE_SUCCESS";
+export const TASK_ENQUEUE_FAILURE = "TASK_ENQUEUE_FAILURE";
 
-export function saveTask(task = {}) {
+export function enqueueTask(task = {}) {
   return (dispatch) => {
-    analytics.track(task.id ? "Created Task" : "Saved Task", task);
+    analytics.track("Enqueued Task", task);
     return dispatch({
       [CALL_API]: {
-        types: [TASK_SAVE_REQUEST, TASK_SAVE_SUCCESS, TASK_SAVE_FAILURE],
+        types: [TASK_ENQUEUE_REQUEST, TASK_ENQUEUE_SUCCESS, TASK_ENQUEUE_FAILURE],
         schema: Schemas.TASK,
-        method: (task.id == "new") ? "POST" : "PUT",
+        method: "POST",
         endpoint: "/tasks",
         data: task,
       },
     }).then((action) => {
-      if (action.type == TASK_SAVE_SUCCESS) {
+      if (action.type == TASK_ENQUEUE_SUCCESS) {
         cancelTaskEdit(task.keyId, task.subject);
       }
     });
   };
 }
 
-export const TASK_DELETE_REQUEST = "TASK_DELETE_REQUEST";
-export const TASK_DELETE_SUCCESS = "TASK_DELETE_SUCCESS";
-export const TASK_DELETE_FAILURE = "TASK_DELETE_FAILURE";
+export const TASK_CANCEL_REQUEST = "TASK_CANCEL_REQUEST";
+export const TASK_CANCEL_SUCCESS = "TASK_CANCEL_SUCCESS";
+export const TASK_CANCEL_FAILURE = "TASK_CANCEL_FAILURE";
 
-export function deleteTask(task = {}) {
-  analytics.track("Deleted Task", task);
+export function cancelTask(task = {}) {
   return (dispatch) => {
+    analytics.track("Cancelled Task", task);
     return dispatch({
       [CALL_API]: {
-        types: [TASK_DELETE_REQUEST, TASK_DELETE_SUCCESS, TASK_DELETE_FAILURE],
+        types: [TASK_CANCEL_REQUEST, TASK_CANCEL_SUCCESS, TASK_CANCEL_FAILURE],
         schema: Schemas.TASK,
-        endpoint: "/tasks",
+        endpoint: `/tasks/${task.id}`,
         method: "DELETE",
         data: task,
       },

--- a/src/js/components/Collection.js
+++ b/src/js/components/Collection.js
@@ -2,9 +2,8 @@ import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
 
 import List from './List';
-import ContentItem from './item/ContentItem';
 
-const Collection = ({ data, sessionKeyId }) => {
+const Collection = ({ data, sessionKeyId, onEdit, onDelete }) => {
   const collection = data;
   return (
     <div id="collection" className="page">
@@ -12,6 +11,8 @@ const Collection = ({ data, sessionKeyId }) => {
         <header className="row">
           <div className="col-md-12">
             <hr className="green" />
+            <a className="right red" onClick={onDelete}>&nbsp; delete</a>
+            <a className="right" onClick={onEdit}>edit</a> 
             <label className="label">Collection</label>
             <h1 className="green">{collection.title}</h1>
           </div>
@@ -24,13 +25,31 @@ const Collection = ({ data, sessionKeyId }) => {
         </div>
         <div className="row">
           <div className="col-md-12">
-            <hr className="green" />
-            <h3 className="green">Contents:</h3>
-            <br />
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>hash</th>
+                  <th>url</th>
+                  <th>description</th>
+                </tr>
+              </thead>
+              <tbody>
+                {collection.contents.map((data, i) => {
+                  const hash = data[0];
+                  const url = data[1];
+                  const description = data[2];
+
+                  return (
+                    <tr key={i} className="">
+                      <td>{ hash && <Link to={`/content/${hash}`}><h5 className="title">{hash}</h5></Link>}</td>
+                      <td>{url}</td>
+                      <td>{description}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
           </div>
-        </div>
-        <div className="row">
-          <List data={collection.contents} component={ContentItem} />
         </div>
       </div>
     </div>

--- a/src/js/components/List.js
+++ b/src/js/components/List.js
@@ -14,7 +14,7 @@ const List = (props) => {
 
   return (
     <div className={className}>
-      {data.map((item, i) => <props.component data={item} key={i} index={i} onSelect={selectFunc(onSelectItem, item, i)} />)}
+      {data.map((item, i) => <props.component {...props} data={item} key={i} index={i} onSelect={selectFunc(onSelectItem, item, i)} />)}
     </div>
   );
 };

--- a/src/js/components/MainMenu.js
+++ b/src/js/components/MainMenu.js
@@ -28,6 +28,7 @@ export default class MainMenu extends React.Component {
         <Link className="blue" to="/primers">Home</Link>
         {/*<Link className="blue" to="/coverage">Coverage</Link>*/}
         <Link className="blue" to="/archives">Datasets</Link>
+        <Link className="blue" to="/collections">Collections</Link>
         {/*<Link className="blue" to="/collections">Collections</Link>*/}
         {/*<Link className="blue" to="/uncrawlables">Uncrawlables</Link>*/}
         {

--- a/src/js/components/form/CollectionForm.js
+++ b/src/js/components/form/CollectionForm.js
@@ -42,7 +42,7 @@ const CollectionForm = ({ name, data, onChange, onCancel, onSubmit }) => {
         </header>
         <div className="row">
           <div className="col-md-12">
-            <ValidInput name="title" value={collection.title} onChange={handleChange} />
+            <ValidInput name="title" label="title" value={collection.title} onChange={handleChange} />
             <br />
             <button className="btn" onClick={onCancel}>Cancel</button>
             <input className="btn btn-primary" type="submit" value="Save" onClick={handleSubmit} />
@@ -63,7 +63,7 @@ const CollectionForm = ({ name, data, onChange, onCancel, onSubmit }) => {
               </thead>
               <tbody>
                 {collection.contents.map((item, i) => {
-                  return <CollectionItem data={item} index={i} onChange={handleItemChange} onDelete={handleItemDelete}  />
+                  return <CollectionItem key={i} data={item} index={i} onChange={handleItemChange} onDelete={handleItemDelete}  />
                 })}
               </tbody>
             </table>
@@ -105,7 +105,7 @@ const CollectionItem = ({data, index, onChange, onDelete}) => {
   }
 
   return (
-    <tr key={index}>
+    <tr>
       <td>{data[0]}</td>
       <td><ValidInput name="url" value={data[1]} onChange={handleChange} /></td>
       <td><ValidInput name="note" value={data[2]} onChange={handleChange} /></td>

--- a/src/js/components/form/CollectionForm.js
+++ b/src/js/components/form/CollectionForm.js
@@ -1,14 +1,35 @@
 import React, { PropTypes } from 'react';
 
+import List from '../List';
 import ValidInput from './ValidInput';
 // import ValidTextarea from './ValidTextarea';
 
-const CollectionForm = ({ data, onChange, onCancel, onSubmit }) => {
+const CollectionForm = ({ name, data, onChange, onCancel, onSubmit }) => {
   const collection = data;
+  const handleChange = (name, value) => {
+    onChange(name, Object.assign({}, data, { [name] : value }));
+  }
   const handleSubmit = (e) => {
     e.preventDefault();
     onSubmit(collection, e);
   };
+
+  const handleItemChange = (index, item) => {
+    let contents = collection.contents.concat()
+    contents.splice(index,1,item);
+
+    onChange(name, Object.assign({}, collection, { contents }));
+  }
+
+  const handleItemDelete = (index) => {
+    // onChange(name, data);
+  }
+
+  const handleAddItem = (e) => {
+    e.preventDefault();
+    let contents = collection.contents || [];
+    onChange(name,Object.assign({}, collection, { contents: contents.concat([["", "", ""]])}));
+  }
 
   return (
     <div id="collection" className="page">
@@ -21,10 +42,32 @@ const CollectionForm = ({ data, onChange, onCancel, onSubmit }) => {
         </header>
         <div className="row">
           <div className="col-md-12">
-            <ValidInput name="title" value={collection.title} onChange={onChange} />
+            <ValidInput name="title" value={collection.title} onChange={handleChange} />
             <br />
             <button className="btn" onClick={onCancel}>Cancel</button>
             <input className="btn btn-primary" type="submit" value="Save" onClick={handleSubmit} />
+          </div>
+        </div>
+        <div className="row">
+          <div className="col-md-12">
+            <hr className="green" />
+            <label className="label">collection items</label>
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>hash</th>
+                  <th>url</th>
+                  <th>description</th>
+                  <th>delete</th>
+                </tr>
+              </thead>
+              <tbody>
+                {collection.contents.map((item, i) => {
+                  return <CollectionItem data={item} index={i} onChange={handleItemChange} onDelete={handleItemDelete}  />
+                })}
+              </tbody>
+            </table>
+            <a onClick={handleAddItem}>add item</a>
           </div>
         </div>
       </div>
@@ -34,10 +77,41 @@ const CollectionForm = ({ data, onChange, onCancel, onSubmit }) => {
 
 CollectionForm.propTypes = {
   data: PropTypes.object.isRequired,
-
+  name: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
 };
+
+CollectionForm.defaultProps = {
+  name : "collection",
+}
+
+const CollectionItem = ({data, index, onChange, onDelete}) => {
+  const handleChange = (name, value) => {
+    // TODO - lol make this not bad
+    switch (name) {
+      case "url":
+        onChange(index, [data[0],value, data[2]])
+        break;
+      case "note":
+        onChange(index, [data[0], data[1], value])
+        break;
+    }
+  }
+
+  const handleDelete = (e) => {
+    onDelete(index);
+  }
+
+  return (
+    <tr key={index}>
+      <td>{data[0]}</td>
+      <td><ValidInput name="url" value={data[1]} onChange={handleChange} /></td>
+      <td><ValidInput name="note" value={data[2]} onChange={handleChange} /></td>
+      <td><a onClick={handleDelete}>delete</a></td>
+    </tr>
+  );
+}
 
 export default CollectionForm;

--- a/src/js/components/form/TaskForm.js
+++ b/src/js/components/form/TaskForm.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Link } from 'react-router';
+
+import ValidInput from './ValidInput';
+import ValidSelect from './ValidSelect';
+
+export default class TaskForm extends React.Component {
+  constructor(props) {
+    super(props);
+    
+    this.state = {
+      task: {
+        taskType: "ipfs.add",
+        params: {
+          url: "https://i.redd.it/59su4dfwq08z.jpg",
+          ipfsApiServerUrl: "http://ipfs:5001/api/v0",
+        },
+      },
+    };
+
+    [
+      "handleSubmit",
+    ].forEach((m) => { this[m] = this[m].bind(this); });
+  }
+
+  handleSubmit() {
+    console.log(this.state.task);
+    this.props.onSubmit(this.state.task);
+  }
+
+  render() {
+    return (
+      <div className="task form col-md-3">
+        <h3>New Task Form</h3>
+        <button className="btn btn-primary" onClick={this.handleSubmit}>Submit Task</button>
+      </div>
+    );
+  }
+};
+
+TaskForm.propTypes = {
+  // data: React.PropTypes.object.isRequired,
+  // onSelect: React.PropTypes.func.isRequired,
+  onSubmit: React.PropTypes.func.isRequired,
+};
+
+TaskForm.defaultProps = {
+};

--- a/src/js/components/form/TaskForm.js
+++ b/src/js/components/form/TaskForm.js
@@ -10,17 +10,27 @@ export default class TaskForm extends React.Component {
     
     this.state = {
       task: {
+        title: "Add to IPFS",
         taskType: "ipfs.add",
         params: {
           url: "https://i.redd.it/59su4dfwq08z.jpg",
-          ipfsApiServerUrl: "http://ipfs:5001/api/v0",
         },
       },
+      validation : {},
+      showErrors : false,
     };
 
     [
+      "handleChange",
       "handleSubmit",
     ].forEach((m) => { this[m] = this[m].bind(this); });
+  }
+
+  handleChange(name, value) {
+    let params = Object.assign({}, this.state.task.params, { [name] : value });
+    let task = Object.assign({}, this.state.task, { params });
+    const change = Object.assign({}, this.state, { task });
+    this.setState(change);
   }
 
   handleSubmit() {
@@ -29,9 +39,12 @@ export default class TaskForm extends React.Component {
   }
 
   render() {
+    const { task, validation, showErrors } = this.state;
+
     return (
       <div className="task form col-md-3">
-        <h3>New Task Form</h3>
+        <h3>Archive Url</h3>
+        <ValidInput type="text" label="Url" name="url" value={task.params.url} error={validation.username} showError={showErrors} onChange={this.handleChange} />
         <button className="btn btn-primary" onClick={this.handleSubmit}>Submit Task</button>
       </div>
     );

--- a/src/js/components/item/TaskItem.js
+++ b/src/js/components/item/TaskItem.js
@@ -7,9 +7,9 @@ const TaskItem = ({ data }) => {
   const task = data;
 
   return (
-    <div className="task item col-md-3">
+    <div className="task item col-md-12">
       <Link to={`/tasks/${task.id}`}>
-        <h4 className="title">{task.name}</h4>
+        <h4 className="title">{task.title}</h4>
         {/*<div className="info">
           <ProgressBar size="micro" color="blue" total={task.stats.contentUrlCount} progress={task.stats.contentMetadataCount} />
           <i>{task.stats.contentMetadataCount}/{task.stats.contentUrlCount}</i>

--- a/src/js/containers/Collection.js
+++ b/src/js/containers/Collection.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router';
+import { Link, browserHistory } from 'react-router';
 
 import analytics from '../analytics';
 import { selectCollection, selectLocalCollection } from '../selectors/collections';
@@ -51,21 +51,24 @@ class Collection extends React.Component {
   }
 
   handleChange(name, value) {
-    console.log(value);
     this.props.updateCollection(value);
   }
   handleCancel() {
-    this.porps.cancelCollectionEdit(this.props.local);
+    this.props.cancelCollectionEdit(this.props.local);
   }
   handleEdit() {
     this.props.editCollection(this.props.collection);
   }
   handleSave() {
-    this.props.saveCollection(this.props.local);
+    this.props.saveCollection(this.props.local, (collection) => {
+      browserHistory.push(`/collections/${collection.id}`);
+    });
   }
   handleDelete() {
     if (confirm("are you sure you want to delete this collection?")) {
-      this.props.deleteCollection(this.props.collection);
+      this.props.deleteCollection(this.props.collection, (collection) => {
+        browserHistory.push(`/collections`);
+      });
     }
   }
 

--- a/src/js/containers/Collection.js
+++ b/src/js/containers/Collection.js
@@ -4,7 +4,15 @@ import { Link } from 'react-router';
 
 import analytics from '../analytics';
 import { selectCollection, selectLocalCollection } from '../selectors/collections';
-import { loadCollection, newCollection, editCollection } from '../actions/collections';
+import { 
+  loadCollection,
+  newCollection,
+  editCollection,
+  updateCollection,
+  saveCollection,
+  deleteCollection,
+  cancelCollectionEdit,
+} from '../actions/collections';
 import { selectDefaultKeyId } from '../selectors/keys';
 
 import Spinner from '../components/Spinner';
@@ -21,7 +29,11 @@ class Collection extends React.Component {
     };
 
     [
-
+      "handleChange",
+      "handleCancel",
+      "handleSave",
+      "handleEdit",
+      "handleDelete",
     ].forEach((m) => { this[m] = this[m].bind(this); });
   }
 
@@ -39,13 +51,22 @@ class Collection extends React.Component {
   }
 
   handleChange(name, value) {
-
+    console.log(value);
+    this.props.updateCollection(value);
   }
   handleCancel() {
-    
+    this.porps.cancelCollectionEdit(this.props.local);
+  }
+  handleEdit() {
+    this.props.editCollection(this.props.collection);
   }
   handleSave() {
-    
+    this.props.saveCollection(this.props.local);
+  }
+  handleDelete() {
+    if (confirm("are you sure you want to delete this collection?")) {
+      this.props.deleteCollection(this.props.collection);
+    }
   }
 
   render() {
@@ -68,7 +89,7 @@ class Collection extends React.Component {
     }
 
     return (
-      <CollectionView data={collection} />
+      <CollectionView data={collection} onEdit={this.handleEdit} onDelete={this.handleDelete} />
     );
   }
 }
@@ -99,4 +120,8 @@ export default connect(mapStateToProps, {
   loadCollection,
   newCollection,
   editCollection,
+  updateCollection,
+  saveCollection,
+  deleteCollection,
+  cancelCollectionEdit,
 })(Collection);

--- a/src/js/containers/Tasks.js
+++ b/src/js/containers/Tasks.js
@@ -3,9 +3,10 @@ import { connect } from 'react-redux';
 
 import analytics from '../analytics';
 import { selectTasks } from '../selectors/tasks';
-import { loadTasks } from '../actions/tasks';
+import { loadTasks, enqueueTask } from '../actions/tasks';
 
 import List from '../components/List';
+import TaskForm from '../components/form/TaskForm';
 import TaskItem from '../components/item/TaskItem';
 import Spinner from '../components/Spinner';
 
@@ -60,6 +61,9 @@ class Tasks extends React.Component {
             <List data={tasks} component={TaskItem} />
           </div>
         </div>
+        <div className="container">
+          <TaskForm onSubmit={this.props.enqueueTask} />
+        </div>
       </div>
     );
   }
@@ -69,6 +73,7 @@ Tasks.propTypes = {
   // user: PropTypes.object,
   tasks: PropTypes.array,
   loadTasks: PropTypes.func.isRequired,
+  enqueueTask: PropTypes.func.isRequired,
 };
 
 function mapStateToProps(state) {
@@ -79,4 +84,5 @@ function mapStateToProps(state) {
 
 export default connect(mapStateToProps, {
   loadTasks,
+  enqueueTask,
 })(Tasks);


### PR DESCRIPTION
This PR brings initial support on the frontend for both tasks & collections. This can only be merged after we merge [the task-mgmt queue refactor](https://github.com/datatogether/task-mgmt/pull/4).

The tasks implementation is extremely skeletal, only one type of task is supported: archiving a url to IPFS. The main job here is to demonstrate the task queue working from end-to-end.

Collections, on the other hand, are much more complete. I think we'll find them useful right off the bat.