### PR TITLE
rename "archives" to "public record"

### DIFF
--- a/src/js/components/MainMenu.js
+++ b/src/js/components/MainMenu.js
@@ -27,7 +27,7 @@ export default class MainMenu extends React.Component {
       <div id="main_menu" onClick={this.onClick} className={show ? "show" : "hide"}>
         <Link className="blue" to="/primers">Home</Link>
         {/*<Link className="blue" to="/coverage">Coverage</Link>*/}
-        <Link className="blue" to="/archives">Datasets</Link>
+        <Link className="blue" to="/public-record">Public Record</Link>
         <Link className="blue" to="/collections">Collections</Link>
         <Link className="blue" to="/communities">Communities</Link>
         {/*<Link className="blue" to="/collections">Collections</Link>*/}

--- a/src/js/containers/PublicRecord.js
+++ b/src/js/containers/PublicRecord.js
@@ -18,7 +18,7 @@ import SearchResultItem from '../components/item/SearchResultItem';
 import ContentItem from '../components/item/ContentItem';
 import SourceItem from '../components/item/SourceItem';
 
-class Archives extends React.Component {
+class PublicRecord extends React.Component {
   constructor(props) {
     super(props);
 
@@ -30,7 +30,7 @@ class Archives extends React.Component {
   }
 
   componentWillMount() {
-    analytics.page('archives');
+    analytics.page('public-record');
     this.props.loadRecentContentUrls(1, 25);
     this.props.loadSources(1, 3);
   }
@@ -100,14 +100,14 @@ class Archives extends React.Component {
     const { query, results } = this.props;
 
     return (
-      <div id="archives" className="archives page">
+      <div id="public-record" className="public-record page">
         <header>
           <div className="container">
             <div className="row">
               <div className="col-md-12">
                 <hr />
                 <div className="form-group">
-                  <label className="form-label label">search archives</label>
+                  <label className="form-label label">search public record</label>
                   <input className="form-control" value={query} onChange={this.handleSearchChange} />
                 </div>
               </div>
@@ -125,12 +125,12 @@ class Archives extends React.Component {
   }
 }
 
-Archives.propTypes = {
+PublicRecord.propTypes = {
   // pages: PropTypes.object.isRequired,
   search: PropTypes.func.isRequired,
 };
 
-Archives.defaultProps = {
+PublicRecord.defaultProps = {
 };
 
 function mapStateToProps(state, ownProps) {
@@ -149,4 +149,4 @@ export default connect(mapStateToProps, {
   loadRecentContentUrls,
   archiveUrl,
   search,
-})(Archives);
+})(PublicRecord);

--- a/src/js/routes.dev.js
+++ b/src/js/routes.dev.js
@@ -3,7 +3,7 @@
  * Gooby pls. Don 4get to update the prod routes.js file
  */
 import App from './containers/App';
-import Archives from './containers/Archives';
+import PublicRecord from './containers/PublicRecord';
 import Coverage from './containers/Coverage';
 import Collection from './containers/Collection';
 import Collections from './containers/Collections';
@@ -48,8 +48,8 @@ export default {
       component: Url,
     },
     {
-      path: "/archives",
-      component: Archives,
+      path: "/public-record",
+      component: PublicRecord,
     },
     {
       path: "/collections",

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -31,9 +31,9 @@ export default {
       },
     },
     {
-      path: "/archives",
+      path: "/public-record",
       getComponent(location, cb) {
-        import('./containers/Archives').then(loadRoute(cb)).catch(errorLoading);
+        import('./containers/PublicRecord').then(loadRoute(cb)).catch(errorLoading);
       },
     },
     {


### PR DESCRIPTION
This shifts to an emphasis on datatogether.org being a view onto the decentralized activities of many communities. When you go to datatogether.org/public-record you're seeing a public record of all the stuff stored/monitored/annotated etc. by any participating orgs.

This feature, the public record, will inevitably evolve. It will very likely end up using some form of blockchain to track entries on a public ledger. It will also be very useful for surfacing things like "`n` people have downloaded this file and reported the same hashes" ... which lets you start talking about Web of Trust...