### PR TITLE
Fixes #46,#47,#48

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,10 +45,10 @@ services:
         -----END RSA PRIVATE KEY-----
 
   patchbay:
-    # image: datatogether/patchbay:latest
-    build: $GOPATH/src/github.com/datatogether/patchbay/
-    volumes:
-      - $GOPATH/src/github.com/datatogether/patchbay:/go/src/github.com/datatogether/patchbay
+    image: datatogether/patchbay:latest
+    # build: $GOPATH/src/github.com/datatogether/patchbay/
+    # volumes:
+    #   - $GOPATH/src/github.com/datatogether/patchbay:/go/src/github.com/datatogether/patchbay
     ports:
      - 3000:3000
     networks:
@@ -81,10 +81,10 @@ services:
       - TITLE=Data Together
 
   task-mgmt:
-    # image: datatogether/task-mgmt:latest
-    build: $GOPATH/src/github.com/datatogether/task-mgmt/
-    volumes:
-      - $GOPATH/src/github.com/datatogether/task-mgmt:/go/src/github.com/datatogether/task-mgmt
+    image: datatogether/task-mgmt:latest
+    # build: $GOPATH/src/github.com/datatogether/task-mgmt/
+    # volumes:
+    #   - $GOPATH/src/github.com/datatogether/task-mgmt:/go/src/github.com/datatogether/task-mgmt
     ports:
      - 3400:3400
      - 4400:4400

--- a/src/js/components/Metadata.js
+++ b/src/js/components/Metadata.js
@@ -1,14 +1,43 @@
 import React, { PropTypes } from 'react';
 
+// order of special keys. most important key is **LAST**
+const keys = ["title", "description", "theme", "keyword"];
+
+// sortPriorityKeys returns a function to be used with Array.prototype.sort()
+// it accepts an array of items to prioritize over natural order comparison.
+// aka: let's you pull stuff out of an alphabetical list to put at the top.
+function priorityCompare(list) {
+  list = list.reverse();
+  return (a,b) => {
+    const ai = list.findIndex((k) => k == a);
+    const bi = list.findIndex((k) => k == b);
+
+    // if neither is a priority string, regular comparison
+    if (ai == -1 && bi == -1) {
+      const nameA = a.toLowerCase(); // ignore upper and lowercase
+      const nameB = b.toLowerCase(); // ignore upper and lowercase
+      if (nameA < nameB) {
+        return -1;
+      }
+      if (nameA > nameB) {
+        return 1;
+      }
+    } else if (ai > bi) {
+      return -1;
+    } else if (ai < bi) {
+      return 1;
+    }
+
+    // equal
+    return 0;
+  }
+}
+
 // Metadata is a static metadata viewer
 const Metadata = ({ metadata }) => {
   return (
     <div className="metadata">
-      {Object.keys(metadata).map((key) => {
-        // TODO - this is a hack for demo purposes. remove when ready.
-        // if (key == "subjectHash" || key == "userId" || key == "requestId") {
-        //   return <div key={key}></div>;
-        // }
+      {Object.keys(metadata).sort(priorityCompare(keys)).map((key) => {
         return (
           <div key={key}>
             <label className="yellow meta label">{key}</label>

--- a/src/js/components/Navbar.js
+++ b/src/js/components/Navbar.js
@@ -11,11 +11,7 @@ const Navbar = ({ user, style, onToggleMenu }) => {
             <Link id="logotype" href={__BUILD__.BASE_URL}>[ data, together ]</Link>
           </div>
           <div className="menu col-md-4 offset-md-2 col-sm-6">
-            {
-              user ?
-                <Link to={`/users/${user.username}`}>{user.username}</Link> :
-                <Link to="/login">Login</Link>
-            }
+            {user && <Link to={`/users/${user.username}`}>{user.username}</Link>}
             <a className="green" onClick={onToggleMenu}>Menu</a>
           </div>
         </div>

--- a/src/js/containers/ArchiveUrl.js
+++ b/src/js/containers/ArchiveUrl.js
@@ -24,6 +24,7 @@ class ArchiveUrl extends React.Component {
     super(props);
     this.state = {
       loading: false,
+      usage: "",
       query: "",
     };
 
@@ -65,7 +66,7 @@ class ArchiveUrl extends React.Component {
   }
 
   render() {
-    const { loading, query } = this.state;
+    const { loading, query, usage } = this.state;
     const { activeTasks, url } = this.props;
 
     return (
@@ -74,7 +75,7 @@ class ArchiveUrl extends React.Component {
           <div className="row">
             <div className="col-md-6 offset-md-3">
               <hr />
-              <h4>Archive a Url</h4>
+              <h4>Add a Dataset</h4>
               <ValidInput
                 name="query"
                 label="URL to archive"
@@ -83,13 +84,13 @@ class ArchiveUrl extends React.Component {
                 placeholder="http://dataseturl.gov"
               />
               <ValidTextarea
-                name="how"
+                name="usage"
                 label="How do you use this dataset?"
-                value=""
+                value={usage}
                 placeholder="I use this data for ..."
                 onChange={this.handleChange}
               />
-              <button className="btn btn-primary" onClick={this.handleArchiveUrl}>Archive</button>
+              <button className="btn btn-primary" onClick={this.handleArchiveUrl}>Add</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Ok, a few changes:
* made the add-dataset "how do you use this" field editable
* changed a little text to remove the phrase "archive"
* metadata display on the content screen now has `title, description, theme, and keyword` pinned to the top of the metadata list in that order (the `priorityCompare` function that does that sorting is pretty fuego, might come in handy elsewhere)
* removed login navbar item when not logged-in, but username will still display if you _are_ logged in.

I'm going to publish this to production b/c it's super easy to revert. Let's use this PR to refine & merge once it's clean.